### PR TITLE
Avoid double-build for pull requests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,7 +2,7 @@ name: Verify
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "**" ]
 


### PR DESCRIPTION
Only pushes to main should be build, PR will be done from other branches